### PR TITLE
 ✨ allow-fast-track-when-automatedCleaning-is-true

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -47,3 +47,11 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+---
+kind: ConfigMap 
+apiVersion: v1 
+metadata:
+  name: fast-track-cm
+  namespace: system
+data:	
+  fastTrack: "false"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -281,3 +281,23 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch


### PR DESCRIPTION
This PR:
    - adds fast track variable as a config map.
    - adds a feature which turn off/on bmh in deprovisioning depending
    on values of AutomatedCleaningMode and FastTrack
    
    AutomatedCleaningMode | FastTrack | BMH
            disabled        false        turn off
            disabled        true          turn off
            metadata        false         turn off
            metadata        true          turn on