### PR TITLE
⚠️ Introduce a flag to structure a M3IPClaimName based on the BMHName instead of M3DataName

### DIFF
--- a/controllers/metal3data_controller.go
+++ b/controllers/metal3data_controller.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	infrav1 "github.com/metal3-io/cluster-api-provider-metal3/api/v1beta1"
-	bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	// bmov1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/metal3-io/cluster-api-provider-metal3/baremetal"
 	ipamv1 "github.com/metal3-io/ip-address-manager/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -155,10 +155,10 @@ func (r *Metal3DataReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 			&source.Kind{Type: &ipamv1.IPClaim{}},
 			handler.EnqueueRequestsFromMapFunc(r.Metal3IPClaimToMetal3Data),
 		).
-		Watches(
-			&source.Kind{Type: &ipamv1.IPClaim{}},
-			handler.EnqueueRequestsFromMapFunc(r.Metal3IPClaimToBaremetalHost),
-		).
+		// Watches(
+		// 	&source.Kind{Type: &ipamv1.IPClaim{}},
+		// 	handler.EnqueueRequestsFromMapFunc(r.Metal3IPClaimToBaremetalHost),
+		// ).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Complete(r)
 }
@@ -193,28 +193,28 @@ func (r *Metal3DataReconciler) Metal3IPClaimToMetal3Data(obj client.Object) []ct
 
 // Metal3IPClaimToBaremetalHost will return a reconcile request for a Metal3Data if the event is for a
 // Metal3IPClaim and that Metal3IPClaim references a BaremetalHost.
-func (r *Metal3DataReconciler) Metal3IPClaimToBaremetalHost(obj client.Object) []ctrl.Request {
-	requests := []ctrl.Request{}
-	if m3ipc, ok := obj.(*ipamv1.IPClaim); ok {
-		for _, ownerRef := range m3ipc.OwnerReferences {
-			if ownerRef.Kind != "BaremetalHost" {
-				continue
-			}
-			aGV, err := schema.ParseGroupVersion(ownerRef.APIVersion)
-			if err != nil {
-				r.Log.Error(err, "failed to parse the API version")
-				continue
-			}
-			if aGV.Group != bmov1alpha1.GroupVersion.Group {
-				continue
-			}
-			requests = append(requests, ctrl.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      ownerRef.Name,
-					Namespace: m3ipc.Namespace,
-				},
-			})
-		}
-	}
-	return requests
-}
+// func (r *Metal3DataReconciler) Metal3IPClaimToBaremetalHost(obj client.Object) []ctrl.Request {
+// 	requests := []ctrl.Request{}
+// 	if m3ipc, ok := obj.(*ipamv1.IPClaim); ok {
+// 		for _, ownerRef := range m3ipc.OwnerReferences {
+// 			if ownerRef.Kind != "BaremetalHost" {
+// 				continue
+// 			}
+// 			aGV, err := schema.ParseGroupVersion(ownerRef.APIVersion)
+// 			if err != nil {
+// 				r.Log.Error(err, "failed to parse the API version")
+// 				continue
+// 			}
+// 			if aGV.Group != bmov1alpha1.GroupVersion.Group {
+// 				continue
+// 			}
+// 			requests = append(requests, ctrl.Request{
+// 				NamespacedName: types.NamespacedName{
+// 					Name:      ownerRef.Name,
+// 					Namespace: m3ipc.Namespace,
+// 				},
+// 			})
+// 		}
+// 	}
+// 	return requests
+// }

--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func initFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(
 		&bmhNameBasedPreallocation,
 		"bmhNameBasedPreallocation",
-		false,
+		true,
 		"Enable PreAllocation field to use Metal3IPClaim name structured with BaremetalHost and M3IPPool names",
 	)
 
@@ -288,7 +288,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		ManagerFactory:   baremetal.NewManagerFactory(mgr.GetClient()),
 		Log:              ctrl.Log.WithName("controllers").WithName("Metal3Data"),
 		WatchFilterValue: watchFilterValue,
-		BMHNameBasedPreallocation: bmhNameBasedPreallocation,
+		// BMHNameBasedPreallocation: bmhNameBasedPreallocation,
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Metal3DataReconciler")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func initFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(
 		&bmhNameBasedPreallocation,
 		"bmhNameBasedPreallocation",
-		true,
+		false,
 		"Enable PreAllocation field to use Metal3IPClaim name structured with BaremetalHost and M3IPPool names",
 	)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As is now, the M3IPClaim name is structured based on the `M3DataName+M3IPPoolName`.
M3DataName is always created in a format of `M3DTemplateName-index`, so when m3m is created and M3D is
requested, the index it will get is random, meaning during upgrade `m3m1` and `m3m2` gets M3Datas created with indexes 0&1
in their names, i.e: M3Data0&M3Data1 accordingly, and on the next upgrade indexes might be inverted (1&0).
To reuse the same IP addresses from IPClaim allocated to m3m through M3Data during the upgrade, we can use a field called
`Preallocations map[claimName]Ipaddr` where `claimName` is structured not the old
way (`M3DataName+M3IPPoolName`) but we make it predictable using `BMH name+M3IPPoolName`, so that
we can predict the claim Name we want to use and reuse the IPaddress again. 
Not to break the current workflow of  M3IPClaim creation, we introduce a new bool flag called `bmhNameBasedPreallocation`, and based on that, we either structure the M3IPClaim name based on the BMH name or fallback using the old
format of structuring the M3IPClaim name based on the M3Data name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
